### PR TITLE
Fix CodeQL high-severity alerts in Quartz source

### DIFF
--- a/quartz/components/scripts/mermaid.inline.ts
+++ b/quartz/components/scripts/mermaid.inline.ts
@@ -207,7 +207,7 @@ document.addEventListener("nav", async () => {
       node.removeAttribute("data-processed")
       const oldText = textMapping.get(node)
       if (oldText) {
-        node.innerHTML = oldText
+        node.textContent = oldText
       }
     }
 

--- a/quartz/util/escape.ts
+++ b/quartz/util/escape.ts
@@ -9,9 +9,9 @@ export const escapeHTML = (unsafe: string) => {
 
 export const unescapeHTML = (html: string) => {
   return html
-    .replaceAll("&amp;", "&")
     .replaceAll("&lt;", "<")
     .replaceAll("&gt;", ">")
     .replaceAll("&quot;", '"')
     .replaceAll("&#039;", "'")
+    .replaceAll("&amp;", "&")
 }

--- a/quartz/util/og.tsx
+++ b/quartz/util/og.tsx
@@ -95,7 +95,7 @@ export async function fetchTtf(
   const css = await cssResponse.text()
 
   // Extract .ttf url from css file
-  const urlRegex = /url\((https:\/\/fonts.gstatic.com\/s\/.*?.ttf)\)/g
+  const urlRegex = /url\((https:\/\/fonts\.gstatic\.com\/s\/.*?\.ttf)\)/g
   const match = urlRegex.exec(css)
 
   if (!match) {


### PR DESCRIPTION
## Summary

  Resolves the three high-severity CodeQL code-scanning alerts that warrant a
  code change. All are in vendored upstream Quartz source; the fixes are minimal
  and forward-portable (worth upstreaming).

  | Alert | Rule | File | Fix |
  |-------|------|------|-----|
  | #1 | `js/double-escaping` | `quartz/util/escape.ts` | Reorder `unescapeHTML` so `&amp;` → `&` runs **last**, preventing double-unescaping (e.g. `&amp;lt;` → `&lt;` → `<`). |
  | #2 | `js/xss-through-dom` | `quartz/components/scripts/mermaid.inline.ts` | Restore the captured diagram source via `node.textContent` instead of `node.innerHTML`. The value is plain text (originally read
  from `innerText`), so this is equivalent and removes the XSS sink. This is the only flagged code that ships to visitors' browsers. |
  | #3 | `js/incomplete-hostname-regexp` | `quartz/util/og.tsx` | Escape the dots in the Google Fonts URL regex (`fonts\.gstatic\.com` / `\.ttf`) so `.` matches a literal dot. |

  ## Alerts handled separately (no code change)

  These were assessed as not warranting code changes in this deployment and were
  dismissed via the GitHub API:

  - **Code scanning #4–7 — `js/path-injection` (`quartz/cli/handlers.js`)** — dismissed *won't fix*. These are in the local `npx quartz build --serve` dev-preview server (read-only `fs.existsSync` checks); the
  deployed GitHub Pages site is static, built with `npx quartz build`, and never runs this code.
  - **Dependabot #34 — `js-yaml` (medium)** — dismissed *tolerable risk*. The vulnerable `js-yaml@3.14.2` is `gray-matter@4.0.3`'s pinned transitive copy (top-level `js-yaml` is already `4.2.0`). `gray-matter`
  calls `safeLoad`/`safeDump`, removed in js-yaml 4.x, so it cannot take the patched `4.2.0`, and it is unmaintained. The quadratic-complexity DoS requires malicious YAML, but `gray-matter` only parses the
  repo's own trusted markdown frontmatter at build time.

  ## Testing

  - `npx quartz build` — succeeds, 465 files emitted, no errors.

  > Note: `tsc --noEmit` reports a **pre-existing** unrelated error (duplicate `readerMode` key in `quartz/i18n/locales/vi-VN.ts`, not touched here); it's a warning under esbuild and does not affect the
  deploy.

  ## Result

  - Dependabot: **0 open**.
  - Code scanning: 4 dismissed; the 3 fixed here auto-close once CodeQL re-scans after merge.